### PR TITLE
Add nod popup and heatmap tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,20 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Heatmap data requirements
+
+The report page includes a gaze heatmap tab that visualizes eye tracking results.
+To render this chart the frontend expects an array of data points with the
+following shape:
+
+```ts
+interface HeatmapPoint {
+  x: number;    // X coordinate of the gaze point in pixels relative to the text
+  y: number;    // Y coordinate in pixels
+  value: number; // Intensity or dwell time value from 0–1
+}
+```
+
+Supplying this array as `heatmapData` in the report API response allows the
+client to generate the heatmap.

--- a/src/components/report/Heatmap.tsx
+++ b/src/components/report/Heatmap.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { HeatmapPoint } from '@/types';
+
+interface HeatmapProps {
+  points: HeatmapPoint[];
+}
+
+export const Heatmap = ({ points }: HeatmapProps) => {
+  const canvasRef = React.useRef<HTMLCanvasElement>(null);
+
+  React.useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    points.forEach(p => {
+      const intensity = Math.max(0, Math.min(1, p.value));
+      const radius = 20;
+      const grd = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, radius);
+      grd.addColorStop(0, `rgba(255,0,0,${intensity})`);
+      grd.addColorStop(1, 'rgba(255,0,0,0)');
+      ctx.fillStyle = grd;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  }, [points]);
+
+  return <canvas ref={canvasRef} width={600} height={400} className="w-full h-96 bg-white border" />;
+};
+

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -84,7 +84,17 @@ export const ReaderPage = () => {
       setNewWords(prev => (prev.includes(word) ? prev : [...prev, word]));
     },
     onNodTwice: ({ wordId, element, word }) => {
-      // Immediately play pronunciation
+      // Show word definition popup above the text
+      const rect = element.getBoundingClientRect();
+      setWordPopup({
+        visible: true,
+        wordId,
+        word,
+        position: { top: rect.bottom, left: rect.left }
+      });
+      setGrammarCard(null);
+
+      // Play pronunciation as additional feedback
       if ('speechSynthesis' in window) {
         const utterance = new SpeechSynthesisUtterance(word);
         utterance.lang = 'en-US';
@@ -93,7 +103,6 @@ export const ReaderPage = () => {
       }
 
       setSessionData(prev => ({ ...prev, nodEvents: prev.nodEvents + 1 }));
-      // do not close the popup here
     },
     onShake: () => {
       setWordPopup(null);

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ArrowLeft, Clock, Eye, Target, BookOpen } from 'lucide-react';
+import { Heatmap } from '@/components/report/Heatmap';
 import type { ReportData } from '@/types';
 import { useReviewWords } from '@/hooks/useReviewWords';
 
@@ -179,10 +180,11 @@ export const ReportPage = () => {
           </CardHeader>
           <CardContent>
             <Tabs defaultValue="overview" className="w-full">
-              <TabsList className="grid w-full grid-cols-3">
+              <TabsList className="grid w-full grid-cols-4">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="difficulties">Difficulties</TabsTrigger>
                 <TabsTrigger value="recommendations">Recommendations</TabsTrigger>
+                <TabsTrigger value="heatmap">Heatmap</TabsTrigger>
               </TabsList>
               
               <TabsContent value="overview" className="space-y-4">
@@ -303,6 +305,10 @@ export const ReportPage = () => {
                     </ul>
                   </div>
                 </div>
+              </TabsContent>
+
+              <TabsContent value="heatmap" className="pt-4">
+                <Heatmap points={reportData.heatmapData} />
               </TabsContent>
             </Tabs>
           </CardContent>


### PR DESCRIPTION
## Summary
- show word definition popup when double nodding occurs
- include simple heatmap component
- add Heatmap tab to the reading report
- document heatmap data format in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889f825250c832b8e70cd492850c390