### PR TITLE
Add reading material schema page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,21 @@ interface HeatmapPoint {
 
 Supplying this array as `heatmapData` in the report API response allows the
 client to generate the heatmap.
+
+## Reading material JSON schema
+
+Uploaded PDFs are converted to structured JSON before displaying in the app. The
+schema is defined in `src/types/index.ts` and summarised below:
+
+```ts
+interface ReadingMaterial {
+  paragraphs: Array<{
+    id: string;
+    text: string;
+    images?: string[]; // optional images extracted or provided by teachers
+  }>;
+  vocabulary: Array<{ word: string; explanation: string }>;
+}
+```
+
+An example is available in the UI at `/schema` for reference.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Index from "@/pages/Index";
 import { ReaderPage } from "@/pages/ReaderPage";
 import { ReportPage } from "@/pages/ReportPage";
 import VocabularyReviewPage from "@/pages/VocabularyReviewPage";
+import MaterialSchemaPage from "@/pages/MaterialSchemaPage";
 import NotFound from "@/pages/NotFound";
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
             <Route path="/reader/:sessionId" element={<ReaderPage />} />
             <Route path="/report/:sessionId" element={<ReportPage />} />
             <Route path="/review" element={<VocabularyReviewPage />} />
+            <Route path="/schema" element={<MaterialSchemaPage />} />
             <Route path="/404" element={<NotFound />} />
             <Route path="*" element={<Navigate to="/404" replace />} />
           </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -129,6 +129,12 @@ const Index = () => {
                     )}
                   </Button>
                 )}
+                <a href="/schema" className="ml-2">
+                  <Button variant="ghost" className="flex items-center space-x-2">
+                    <Settings className="h-4 w-4" />
+                    <span>Schema</span>
+                  </Button>
+                </a>
               </div>
 
               <Button variant="ghost" size="icon" onClick={handleLogout}>
@@ -183,6 +189,11 @@ const Index = () => {
                   )}
                 </Button>
               )}
+              <a href="/schema" className="ml-1">
+                <Button variant="ghost" size="sm">
+                  Schema
+                </Button>
+              </a>
             </div>
           </div>
         </div>

--- a/src/pages/MaterialSchemaPage.tsx
+++ b/src/pages/MaterialSchemaPage.tsx
@@ -1,0 +1,59 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const example = {
+  paragraphs: [
+    {
+      id: "p1",
+      text: "Emma has been learning English for two years. She finds reading comprehension relatively easy...",
+      images: ["https://example.com/p1.png"]
+    },
+    {
+      id: "p2",
+      text: "Her teacher believes that with consistent practice Emma will become more fluent...",
+      images: []
+    }
+  ],
+  vocabulary: [
+    {
+      word: "comprehension",
+      explanation: "The ability to understand something"
+    },
+    {
+      word: "fluent",
+      explanation: "Able to speak a language easily and well"
+    }
+  ]
+};
+
+export const MaterialSchemaPage = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gray-50">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>Reading Material Schema</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-600">
+            OCR results from uploaded PDFs are stored using this structure.
+          </p>
+          <pre className="bg-gray-100 p-4 rounded text-xs overflow-auto">
+{`interface ReadingMaterial {
+  paragraphs: Array<{
+    id: string;
+    text: string;
+    images?: string[]; // optional image URLs or base64 data
+  }>;
+  vocabulary: Array<{ word: string; explanation: string }>;
+}`}
+          </pre>
+          <p className="text-sm text-gray-600">Example output:</p>
+          <pre className="bg-gray-100 p-4 rounded text-xs overflow-auto">
+{JSON.stringify(example, null, 2)}
+          </pre>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default MaterialSchemaPage;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,3 +55,20 @@ export interface ReadingSession {
   endTime?: number;
   isActive: boolean;
 }
+
+// Reading material extracted from PDFs
+export interface Paragraph {
+  id: string;
+  text: string;
+  images?: string[];
+}
+
+export interface VocabularyItem {
+  word: string;
+  explanation: string;
+}
+
+export interface ReadingMaterial {
+  paragraphs: Paragraph[];
+  vocabulary: VocabularyItem[];
+}


### PR DESCRIPTION
## Summary
- define `ReadingMaterial` types
- document new schema in README
- add a page that displays the schema and example JSON
- expose the new page via a route and navigation link

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688b0352bfa8832bb2274ee9cb78c0e2