### PR TITLE
Add image reading demo with voice

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { ReportPage } from "@/pages/ReportPage";
 import VocabularyReviewPage from "@/pages/VocabularyReviewPage";
 import MaterialSchemaPage from "@/pages/MaterialSchemaPage";
 import NotFound from "@/pages/NotFound";
+import ImageReaderPage from "@/pages/ImageReaderPage";
 
 function App() {
   return (
@@ -19,6 +20,7 @@ function App() {
             <Route path="/reader/:sessionId" element={<ReaderPage />} />
             <Route path="/report/:sessionId" element={<ReportPage />} />
             <Route path="/review" element={<VocabularyReviewPage />} />
+            <Route path="/image-reader" element={<ImageReaderPage />} />
             <Route path="/schema" element={<MaterialSchemaPage />} />
             <Route path="/404" element={<NotFound />} />
             <Route path="*" element={<Navigate to="/404" replace />} />

--- a/src/components/reader/ImageDisplay.tsx
+++ b/src/components/reader/ImageDisplay.tsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+
+interface ImageDisplayProps {
+  id: string;
+  src: string;
+  text: string;
+  isHighlighted?: boolean;
+  autoSpeak?: boolean;
+}
+
+export const ImageDisplay = ({ id, src, text, isHighlighted = false, autoSpeak = false }: ImageDisplayProps) => {
+  useEffect(() => {
+    if (autoSpeak && isHighlighted && 'speechSynthesis' in window) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'en-US';
+      utterance.rate = 0.9;
+      speechSynthesis.speak(utterance);
+    }
+  }, [autoSpeak, isHighlighted, text]);
+
+  return (
+    <img
+      id={id}
+      src={src}
+      alt={text}
+      className={`mx-auto rounded shadow transition-transform duration-300 ${isHighlighted ? 'scale-125 ring-2 ring-blue-300' : 'scale-100'}`}
+    />
+  );
+};
+
+export default ImageDisplay;

--- a/src/pages/ImageReaderPage.tsx
+++ b/src/pages/ImageReaderPage.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import ImageDisplay from '@/components/reader/ImageDisplay';
+
+const items = [
+  {
+    id: 'img1',
+    src: '/placeholder.svg',
+    text: 'Emma has been learning English for two years.'
+  },
+  {
+    id: 'img2',
+    src: '/placeholder.svg',
+    text: 'Her teacher believes consistent practice improves fluency.'
+  }
+];
+
+export const ImageReaderPage = () => {
+  const [focusId, setFocusId] = useState<string | null>(null);
+
+  const speak = (text: string) => {
+    if ('speechSynthesis' in window) {
+      const u = new SpeechSynthesisUtterance(text);
+      u.lang = 'en-US';
+      u.rate = 0.9;
+      speechSynthesis.speak(u);
+    }
+  };
+
+  const triggerDistraction = (id: string) => {
+    setFocusId(id);
+    speak(items.find(i => i.id === id)?.text || '');
+    setTimeout(() => setFocusId(null), 3000);
+  };
+
+  return (
+    <div className="min-h-screen p-4 bg-gray-50">
+      <Card className="max-w-xl mx-auto">
+        <CardHeader>
+          <CardTitle className="text-lg">Image Reading Session</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {items.map(item => (
+            <div key={item.id} className="space-y-2">
+              <ImageDisplay id={item.id} src={item.src} text={item.text} isHighlighted={focusId === item.id} />
+              <Button size="sm" onClick={() => speak(item.text)}>
+                Speak
+              </Button>
+            </div>
+          ))}
+          <Button variant="outline" onClick={() => triggerDistraction(items[0].id)}>
+            Simulate Distraction
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ImageReaderPage;


### PR DESCRIPTION
## Summary
- add `ImageDisplay` component to render images that can be enlarged and optionally voiced
- introduce `ImageReaderPage` to demonstrate image-based reading with a distraction event and TTS support
- register `/image-reader` route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b23ef0b58832b80fc72db3af727a6