### PR TITLE
Add gaze heatmap generation and Chinese demo text

### DIFF
--- a/src/data/defaultGazeData.ts
+++ b/src/data/defaultGazeData.ts
@@ -1,0 +1,13 @@
+import type { GazePacket } from '@/types';
+
+export const defaultGazeData: GazePacket[] = [
+  { timestamp: 0, gaze_valid: 1, gaze_pos_x: 120, gaze_pos_y: 220 },
+  { timestamp: 100, gaze_valid: 1, gaze_pos_x: 125, gaze_pos_y: 225 },
+  { timestamp: 200, gaze_valid: 1, gaze_pos_x: 130, gaze_pos_y: 230 },
+  { timestamp: 300, gaze_valid: 1, gaze_pos_x: 200, gaze_pos_y: 260 },
+  { timestamp: 400, gaze_valid: 1, gaze_pos_x: 205, gaze_pos_y: 265 },
+  { timestamp: 500, gaze_valid: 1, gaze_pos_x: 210, gaze_pos_y: 270 },
+  { timestamp: 600, gaze_valid: 1, gaze_pos_x: 400, gaze_pos_y: 120 },
+  { timestamp: 700, gaze_valid: 1, gaze_pos_x: 405, gaze_pos_y: 125 },
+  { timestamp: 800, gaze_valid: 1, gaze_pos_x: 410, gaze_pos_y: 130 },
+];

--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -1,0 +1,44 @@
+import type { GazePacket, HeatmapPoint } from '@/types';
+
+/**
+ * Generate heatmap data by calculating gaze point density.
+ * @param gazeData Array of gaze packets from a reading session
+ * @param width Canvas width in pixels
+ * @param height Canvas height in pixels
+ * @param cellSize Size of a grid cell in pixels
+ */
+export function generateHeatmapData(
+  gazeData: GazePacket[],
+  width = 600,
+  height = 400,
+  cellSize = 30
+): HeatmapPoint[] {
+  const cols = Math.ceil(width / cellSize);
+  const rows = Math.ceil(height / cellSize);
+  const grid = new Array(cols * rows).fill(0);
+
+  gazeData.forEach(p => {
+    if (p.gaze_valid !== 1) return;
+    const col = Math.floor(p.gaze_pos_x / cellSize);
+    const row = Math.floor(p.gaze_pos_y / cellSize);
+    if (col >= 0 && col < cols && row >= 0 && row < rows) {
+      grid[row * cols + col] += 1;
+    }
+  });
+
+  const max = Math.max(...grid, 1);
+  const points: HeatmapPoint[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const val = grid[r * cols + c];
+      if (val > 0) {
+        points.push({
+          x: c * cellSize + cellSize / 2,
+          y: r * cellSize + cellSize / 2,
+          value: val / max,
+        });
+      }
+    }
+  }
+  return points;
+}

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -16,7 +16,8 @@ export const ReaderPage = () => {
   const navigate = useNavigate();
   
   // Sample text content - in real app, this would come from API
-  const textContent = `Emma has been learning English for two years. She finds reading comprehension relatively easy, but speaking still makes her nervous. The pronunciation of certain sounds, particularly the "th" sound in words like "think" and "through," continues to challenge her. Her teacher believes that with consistent practice and confidence-building exercises, Emma will become much more fluent in spoken English. Reading books and articles helps Emma expand her vocabulary and understand different sentence structures.`;
+  // Immersive reading material translated into Chinese
+  const textContent = `艾瑪學習英語已經兩年了。她覺得閱讀理解相對容易，但口說仍然讓她緊張。某些音的發音，尤其是像 "think" 和 "through" 中的 "th" 音，仍然讓她困擾。老師認為只要持續練習並建立自信，艾瑪將能在口說英語上更加流利。閱讀書籍和文章有助於艾瑪擴充詞彙並理解不同的句子結構。`;
 
   // Core state management
   const [isGazeActive, setIsGazeActive] = useState(false);
@@ -236,12 +237,26 @@ export const ReaderPage = () => {
     const updated = Array.from(new Set([...existing, ...newWords]));
     localStorage.setItem('reviewWords', JSON.stringify(updated));
 
-    console.log('Uploading session data:', {
-      sessionId,
+    const positions: Record<string, { x: number; y: number; width: number; height: number }> = {};
+    elementPositionsRef.current.forEach((rect, id) => {
+      positions[id] = {
+        x: rect.x + window.scrollX,
+        y: rect.y + window.scrollY,
+        width: rect.width,
+        height: rect.height
+      };
+    });
+
+    const sessionPayload = {
       gazeData: fullSessionData.current,
       sessionStats: sessionData,
+      positions,
       newWords
-    });
+    };
+
+    localStorage.setItem(`session-${sessionId}`, JSON.stringify(sessionPayload));
+
+    console.log('Uploading session data:', { sessionId, ...sessionPayload });
     
     navigate(`/report/${sessionId}`);
   };

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -21,25 +21,38 @@ export const ReportPage = () => {
   useEffect(() => {
     const fetchReport = async () => {
       setIsLoading(true);
-      
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      // Mock report data
+
+      await new Promise(resolve => setTimeout(resolve, 500));
+
+      const stored = localStorage.getItem(`session-${sessionId}`);
+      let gazeData;
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          gazeData = parsed.gazeData;
+        } catch {
+          gazeData = null;
+        }
+      }
+
+      if (!gazeData) {
+        const { defaultGazeData } = await import('@/data/defaultGazeData');
+        gazeData = defaultGazeData;
+      }
+
+      const { generateHeatmapData } = await import('@/lib/heatmap');
+      const heatmapData = generateHeatmapData(gazeData, 600, 400);
+
       const mockReport: ReportData = {
         summary: {
-          readingTime: 185000, // 3 minutes 5 seconds
+          readingTime: 185000,
           avgFixationDuration: 250,
           regressionRate: 12,
           focusScore: 85,
           wordsRead: 87,
           comprehensionLevel: 'high'
         },
-        heatmapData: [
-          { x: 100, y: 200, value: 0.8 },
-          { x: 150, y: 220, value: 0.6 },
-          { x: 200, y: 240, value: 0.9 }
-        ],
+        heatmapData,
         highlightSentences: ['sentence-2', 'sentence-5'],
         difficultWords: [
           { word: 'pronunciation', fixationTime: 1200, lookupCount: 1 },
@@ -47,7 +60,7 @@ export const ReportPage = () => {
           { word: 'particularly', fixationTime: 600, lookupCount: 0 }
         ]
       };
-      
+
       setReportData(mockReport);
       setIsLoading(false);
     };


### PR DESCRIPTION
## Summary
- implement demo heatmap generation from gaze points
- store element positions and gaze data in session storage
- use default data if none is recorded
- translate immersive reading sample text into Chinese

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b25bf21a0832b8dfe8fcd4ffe5480