### PR TITLE
Add follow-along and syllable display features

### DIFF
--- a/src/components/reader/GrammarCard.tsx
+++ b/src/components/reader/GrammarCard.tsx
@@ -2,15 +2,16 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { X, BookOpen } from 'lucide-react';
+import { X, BookOpen, Mic } from 'lucide-react';
 
 interface GrammarCardProps {
   sentence: string;
   position: { top: number; left: number };
   onClose: () => void;
+  onFollowAlong?: (text: string, position: { top: number; left: number }) => void;
 }
 
-export const GrammarCard = ({ sentence, position, onClose }: GrammarCardProps) => {
+export const GrammarCard = ({ sentence, position, onClose, onFollowAlong }: GrammarCardProps) => {
   // Mock grammar analysis - in real implementation, this would come from AI/NLP service
   const grammarAnalysis = {
     tense: 'Present Perfect',
@@ -40,6 +41,16 @@ export const GrammarCard = ({ sentence, position, onClose }: GrammarCardProps) =
               <div className="flex items-center space-x-2">
                 <BookOpen className="h-4 w-4 text-green-600" />
                 <span className="font-medium text-green-700">Grammar Help</span>
+                {onFollowAlong && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onFollowAlong(sentence, position)}
+                    className="text-green-600 hover:text-green-800 p-1 h-auto"
+                  >
+                    <Mic className="h-4 w-4" />
+                  </Button>
+                )}
               </div>
               <Button
                 variant="ghost"

--- a/src/components/reader/WordPopup.tsx
+++ b/src/components/reader/WordPopup.tsx
@@ -2,12 +2,13 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Volume2, X } from 'lucide-react';
+import { Volume2, Mic, X } from 'lucide-react';
 
 interface WordPopupProps {
   word: string;
   position: { top: number; left: number };
   onClose: () => void;
+  onFollowAlong?: (text: string, position: { top: number; left: number }) => void;
 }
 
 interface WordDefinition {
@@ -18,7 +19,7 @@ interface WordDefinition {
   examples: string[];
 }
 
-export const WordPopup = ({ word, position, onClose }: WordPopupProps) => {
+export const WordPopup = ({ word, position, onClose, onFollowAlong }: WordPopupProps) => {
   const [definition, setDefinition] = useState<WordDefinition | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isFlipped, setIsFlipped] = useState(false);
@@ -86,6 +87,16 @@ export const WordPopup = ({ word, position, onClose }: WordPopupProps) => {
                   >
                     <Volume2 className="h-4 w-4" />
                   </Button>
+                  {onFollowAlong && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onFollowAlong(definition.word, position)}
+                      className="text-green-600 hover:text-green-800 p-1 h-auto"
+                    >
+                      <Mic className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
                 <Button
                   variant="ghost"

--- a/src/lib/syllables.ts
+++ b/src/lib/syllables.ts
@@ -1,0 +1,22 @@
+export const splitIntoSyllables = (word: string): string[] => {
+  const lower = word.toLowerCase();
+  const vowels = 'aeiouy';
+  const syllables: string[] = [];
+  let current = '';
+
+  for (let i = 0; i < lower.length; i++) {
+    const char = lower[i];
+    current += word[i];
+    const next = lower[i + 1];
+    const isVowel = vowels.includes(char);
+    const nextIsVowel = vowels.includes(next);
+
+    if (isVowel && (!next || !nextIsVowel)) {
+      syllables.push(current);
+      current = '';
+    }
+  }
+
+  if (current) syllables.push(current);
+  return syllables;
+};

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -8,6 +8,8 @@ import { Eye, EyeOff, Save, ArrowLeft } from 'lucide-react';
 import { TextDisplay } from '@/components/reader/TextDisplay';
 import { WordPopup } from '@/components/reader/WordPopup';
 import { GrammarCard } from '@/components/reader/GrammarCard';
+import { FollowAlongWidget } from '@/components/FollowAlongWidget';
+import { PronunciationFeedback } from '@/components/PronunciationFeedback';
 import { useGazeEvents } from '@/hooks/useGazeEvents';
 import type { GazePacket, WordPopupData, GrammarCardData } from '@/types';
 
@@ -34,7 +36,15 @@ export const ReaderPage = () => {
   // Enhanced interaction states
   const [newWords, setNewWords] = useState<string[]>([]);
   const [demoMode, setDemoMode] = useState(false);
+  const [followAlongTarget, setFollowAlongTarget] = useState<{ text: string; position: { x: number; y: number } } | null>(null);
+  const [feedbackData, setFeedbackData] = useState<{ audioBlob: Blob; text: string } | null>(null);
 
+  const handleRecordingComplete = (audioBlob: Blob) => {
+    if (followAlongTarget) {
+      setFeedbackData({ audioBlob, text: followAlongTarget.text });
+      setFollowAlongTarget(null);
+    }
+  };
 
 
 
@@ -404,6 +414,9 @@ export const ReaderPage = () => {
           word={wordPopup.word}
           position={wordPopup.position}
           onClose={() => setWordPopup(null)}
+          onFollowAlong={(text, pos) =>
+            setFollowAlongTarget({ text, position: { x: pos.left, y: pos.top } })
+          }
         />
       )}
 
@@ -412,6 +425,26 @@ export const ReaderPage = () => {
           sentence={grammarCard.sentence}
           position={grammarCard.position}
           onClose={() => setGrammarCard(null)}
+          onFollowAlong={(text, pos) =>
+            setFollowAlongTarget({ text, position: { x: pos.left, y: pos.top } })
+          }
+        />
+      )}
+
+      {followAlongTarget && (
+        <FollowAlongWidget
+          text={followAlongTarget.text}
+          position={followAlongTarget.position}
+          onClose={() => setFollowAlongTarget(null)}
+          onRecordingComplete={handleRecordingComplete}
+        />
+      )}
+
+      {feedbackData && (
+        <PronunciationFeedback
+          audioBlob={feedbackData.audioBlob}
+          originalText={feedbackData.text}
+          onClose={() => setFeedbackData(null)}
         />
       )}
     </div>

--- a/src/pages/VocabularyReviewPage.tsx
+++ b/src/pages/VocabularyReviewPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useReviewWords } from '@/hooks/useReviewWords';
+import { splitIntoSyllables } from '@/lib/syllables';
 
 export const VocabularyReviewPage = () => {
   const { words, removeWord } = useReviewWords();
@@ -21,6 +22,7 @@ export const VocabularyReviewPage = () => {
   }
 
   const word = words[index];
+  const syllables = splitIntoSyllables(word);
 
   const handleKnown = () => {
     removeWord(word);
@@ -42,7 +44,16 @@ export const VocabularyReviewPage = () => {
           <CardTitle>單字複習</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4 text-center">
-          <div className="text-3xl font-bold">{word}</div>
+          <div className="text-3xl font-bold flex justify-center space-x-1">
+            {syllables.map((syl, i) => (
+              <span key={i}>
+                {syl}
+                {i < syllables.length - 1 && (
+                  <span className="text-blue-600">•</span>
+                )}
+              </span>
+            ))}
+          </div>
           <div className="flex justify-around">
             <Button onClick={handleKnown} className="bg-green-600 hover:bg-green-700">記得</Button>
             <Button variant="outline" onClick={handleAgain}>再一次</Button>


### PR DESCRIPTION
## Summary
- display syllables on each review flashcard
- allow follow-along practice from word or sentence popups
- show recording indicator and feedback after follow-along
- utility for naive syllable splitting

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c5d262ff4832b8df955de446789e2