### PR TITLE
Integrate realtime gaze data

### DIFF
--- a/public/realtime-demo.json
+++ b/public/realtime-demo.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "realtime_data",
+    "timestamp": "2025-08-01T14:14:03.501Z",
+    "gaze": { "x": 120.5, "y": 220.3, "valid": 1 },
+    "distance": 28.5,
+    "behaviors": { "nod_count": 0, "nod_states": [] },
+    "eyetrack_states": {},
+    "text_detection": []
+  },
+  {
+    "type": "realtime_data",
+    "timestamp": "2025-08-01T14:14:03.551Z",
+    "gaze": { "x": 125.1, "y": 225.2, "valid": 1 },
+    "distance": 28.5,
+    "behaviors": { "nod_count": 0, "nod_states": [] },
+    "eyetrack_states": {},
+    "text_detection": []
+  }
+]

--- a/src/lib/realtimeDataTransform.ts
+++ b/src/lib/realtimeDataTransform.ts
@@ -1,0 +1,28 @@
+import type { GazePacket } from '@/types'
+
+export interface RealtimeData {
+  type: 'realtime_data'
+  timestamp: string
+  gaze: { x: number; y: number; valid: 0 | 1 }
+  distance?: number
+  behaviors?: unknown
+  eyetrack_states?: unknown
+  text_detection?: unknown[]
+  pupil_diameter?: number
+  blink_detected?: boolean
+}
+
+export function toGazePacket(data: RealtimeData): GazePacket {
+  return {
+    timestamp: Date.parse(data.timestamp),
+    gaze_valid: data.gaze.valid,
+    gaze_pos_x: data.gaze.x,
+    gaze_pos_y: data.gaze.y,
+    ...(data.pupil_diameter !== undefined && { pupil_diameter: data.pupil_diameter }),
+    ...(data.blink_detected !== undefined && { blink_detected: data.blink_detected })
+  }
+}
+
+export function toGazePackets(arr: RealtimeData[]): GazePacket[] {
+  return arr.map(toGazePacket)
+}

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -10,6 +10,10 @@ import { WordPopup } from '@/components/reader/WordPopup';
 import { GrammarCard } from '@/components/reader/GrammarCard';
 import { useGazeEvents } from '@/hooks/useGazeEvents';
 import type { GazePacket, WordPopupData, GrammarCardData } from '@/types';
+import {
+  toGazePackets,
+  type RealtimeData
+} from '@/lib/realtimeDataTransform';
 
 export const ReaderPage = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
@@ -144,6 +148,25 @@ export const ReaderPage = () => {
     };
 
     const interval = setInterval(simulateGazeData, 50);
+    return () => clearInterval(interval);
+  }, [isGazeActive]);
+
+  // Fetch realtime gaze data from backend (or local mock)
+  useEffect(() => {
+    if (!isGazeActive) return;
+
+    const fetchRealtime = async () => {
+      try {
+        const res = await fetch('/api/realtime');
+        if (!res.ok) return;
+        const data: RealtimeData[] = await res.json();
+        gazeDataQueue.current.push(...toGazePackets(data));
+      } catch (err) {
+        console.error('Failed to fetch realtime data', err);
+      }
+    };
+
+    const interval = setInterval(fetchRealtime, 200);
     return () => clearInterval(interval);
   }, [isGazeActive]);
 


### PR DESCRIPTION
## Summary
- convert backend `RealtimeData` objects into `GazePacket`
- fetch realtime eye–tracking data in `ReaderPage`
- provide sample `realtime-demo.json`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c5cf2f384832b84b7bf090a2075e2