### PR TITLE
Fix realtime fetch url for subfolder deployments

### DIFF
--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -167,7 +167,7 @@ export const ReaderPage = () => {
 
     const fetchRealtime = async () => {
       try {
-        const res = await fetch('/api/realtime');
+        const res = await fetch(`${import.meta.env.BASE_URL}api/realtime`);
         if (!res.ok) return;
         const data: RealtimeData[] = await res.json();
         gazeDataQueue.current.push(...toGazePackets(data));


### PR DESCRIPTION
## Summary
- ensure ReaderPage fetches realtime data using the configured Vite base url

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c8a90d75c832b91c5a0368b067112