### PR TITLE
Fix chat input key handler

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -171,7 +171,7 @@ export const ChatInterface = () => {
                 value={newMessage}
                 onChange={(e) => setNewMessage(e.target.value)}
                 placeholder="輸入訊息..."
-                onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
+                onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
                 className="flex-1"
               />
               <Button onClick={handleSendMessage} size="sm">


### PR DESCRIPTION
## Summary
- change chat input handler from `onKeyPress` to `onKeyDown` so Enter sends message

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c8a8e393c832bbf1b90011164c95f