### PR TITLE
Fix due date display on EnhancedStudentDashboard

### DIFF
--- a/src/components/EnhancedStudentDashboard.tsx
+++ b/src/components/EnhancedStudentDashboard.tsx
@@ -68,7 +68,7 @@ export const EnhancedStudentDashboard = () => {
     const now = new Date();
     const diffTime = due.getTime() - now.getTime();
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-    return diffDays;
+    return Math.max(diffDays, 0);
   };
 
   const getStatusColor = (status: string) => {
@@ -129,7 +129,11 @@ export const EnhancedStudentDashboard = () => {
                         variant="secondary" 
                         className={getStatusColor(assignment.status)}
                       >
-                        {assignment.status === 'completed' ? '已完成' : `剩餘 ${getDaysUntilDue(assignment.dueDate)} 天`}
+                        {assignment.status === 'completed'
+                          ? '已完成'
+                          : getDaysUntilDue(assignment.dueDate) === 0
+                          ? '已過期'
+                          : `剩餘 ${getDaysUntilDue(assignment.dueDate)} 天`}
                       </Badge>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- clamp negative days until due to zero
- show "已過期" badge when assignment is overdue

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688c8a8c80e0832bb7f797a0a86c2d95