### PR TITLE
Implement backend heatmap fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ To provide grammar tips when a learner focuses on a sentence, the app can fetch 
 ```
 
 Use `fetchGrammarDemo()` from `src/lib/grammarEndpoint.ts` to retrieve and parse this data on the client.
+
+## Heatmap generation
+
+When a report is viewed the app tries to load gaze points from `realtime-demo.json`. These points are transformed using `toGazePackets()` and combined with any locally stored data before generating heatmap values. If loading fails or no gaze data is available, the default sample in `src/data/defaultGazeData.ts` is used so the heatmap still renders.

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -35,7 +35,19 @@ export const ReportPage = () => {
         }
       }
 
-      if (!gazeData) {
+      try {
+        const res = await fetch('/realtime-demo.json');
+        if (res.ok) {
+          const backendData = await res.json();
+          const { toGazePackets } = await import('@/lib/realtimeDataTransform');
+          const packets = toGazePackets(backendData);
+          gazeData = gazeData ? [...gazeData, ...packets] : packets;
+        }
+      } catch (err) {
+        console.error('Failed to fetch realtime data', err);
+      }
+
+      if (!gazeData || gazeData.length === 0) {
         const { defaultGazeData } = await import('@/data/defaultGazeData');
         gazeData = defaultGazeData;
       }


### PR DESCRIPTION
## Summary
- fetch realtime gaze data from `realtime-demo.json` when building the report
- describe heatmap generation in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c8cb04f30832baf610ff2aa5a802a