### PR TITLE
Implement gaze-driven TTS service

### DIFF
--- a/src/components/TTSSettingsPanel.tsx
+++ b/src/components/TTSSettingsPanel.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import type { TextContentTTSService } from '@/services/TextContentTTSService';
+
+interface Props {
+  service: TextContentTTSService;
+  onClose: () => void;
+}
+
+export const TTSSettingsPanel = ({ service, onClose }: Props) => {
+  const settings = service.getSettings();
+  const [rate, setRate] = useState([settings.rate]);
+  const [pitch, setPitch] = useState([settings.pitch]);
+  const [enabled, setEnabled] = useState(settings.enabled);
+  const [autoSpeak, setAutoSpeak] = useState(settings.autoSpeak);
+
+  const handleSave = () => {
+    service.updateSettings({
+      rate: rate[0],
+      pitch: pitch[0],
+      enabled,
+      autoSpeak,
+    });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onClick={onClose}>
+      <Card className="w-80" onClick={(e) => e.stopPropagation()}>
+        <CardHeader>
+          <CardTitle className="text-lg">TTS 設定</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">啟用 TTS</span>
+            <Switch checked={enabled} onCheckedChange={setEnabled} />
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm">自動朗讀</span>
+            <Switch checked={autoSpeak} onCheckedChange={setAutoSpeak} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm">語速：{rate[0].toFixed(1)}</label>
+            <Slider value={rate} onValueChange={setRate} min={0.5} max={2} step={0.1} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm">音調：{pitch[0].toFixed(1)}</label>
+            <Slider value={pitch} onValueChange={setPitch} min={0} max={2} step={0.1} />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={onClose} size="sm">取消</Button>
+            <Button onClick={handleSave} size="sm">儲存</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/hooks/useGazeEvents.ts
+++ b/src/hooks/useGazeEvents.ts
@@ -166,25 +166,25 @@ export const useGazeEvents = (handlers: GazeEventHandlers) => {
           fixationRef.current = { wordId: null, startTime: 0 };
         }
       }
+      } else {
+        // Not on a word, reset fixation and nod detection
+        fixationRef.current = { wordId: null, startTime: 0 };
+        nodDetectionRef.current = {
+          ...nodDetectionRef.current,
+          wordId: null,
+          verticalMovements: [],
+          lastMovementTime: 0
+        };
+      }
     } catch (error) {
       console.error('Error in word fixation detection:', error);
       // Reset state on error to prevent stuck states
       fixationRef.current = { wordId: null, startTime: 0 };
-      nodDetectionRef.current = { 
+      nodDetectionRef.current = {
         ...nodDetectionRef.current,
-        wordId: null, 
-        verticalMovements: [], 
-        lastMovementTime: 0 
-      };
-    }
-    } else {
-      // Not on a word, reset fixation and nod detection
-      fixationRef.current = { wordId: null, startTime: 0 };
-      nodDetectionRef.current = { 
-        ...nodDetectionRef.current,
-        wordId: null, 
-        verticalMovements: [], 
-        lastMovementTime: 0 
+        wordId: null,
+        verticalMovements: [],
+        lastMovementTime: 0
       };
     }
 

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -4,18 +4,20 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Eye, EyeOff, Save, ArrowLeft } from 'lucide-react';
+import { Eye, EyeOff, Save, ArrowLeft, Volume2, Settings, Square } from 'lucide-react';
 import { TextDisplay } from '@/components/reader/TextDisplay';
 import { WordPopup } from '@/components/reader/WordPopup';
 import { GrammarCard } from '@/components/reader/GrammarCard';
 import { FollowAlongWidget } from '@/components/FollowAlongWidget';
 import { PronunciationFeedback } from '@/components/PronunciationFeedback';
+import { TTSSettingsPanel } from '@/components/TTSSettingsPanel';
 import { useGazeEvents } from '@/hooks/useGazeEvents';
 import type { GazePacket, WordPopupData, GrammarCardData } from '@/types';
 import {
   toGazePackets,
   type RealtimeData
 } from '@/lib/realtimeDataTransform';
+import { TextContentTTSService } from '@/services/TextContentTTSService';
 
 type WsStatus = 'connecting' | 'connected' | 'disconnected';
 
@@ -29,7 +31,15 @@ export const ReaderPage = () => {
   useEffect(() => {
     fetch('/text/sample.txt')
       .then((res) => res.text())
-      .then(setTextContent)
+      .then(async (content) => {
+        setTextContent(content);
+        setTimeout(async () => {
+          if (textDisplayRef.current) {
+            await textTTSService.current.load(textDisplayRef.current);
+            setTTSEnabled(textTTSService.current.getSettings().enabled);
+          }
+        }, 300);
+      })
       .catch((err) => console.error('Failed to load text', err));
   }, []);
 
@@ -55,6 +65,11 @@ export const ReaderPage = () => {
   const [usingRealData, setUsingRealData] = useState(false);
   const [lastRealDataTime, setLastRealDataTime] = useState(0);
   const [currentNodCount, setCurrentNodCount] = useState(0);
+  const [showTTSSettings, setShowTTSSettings] = useState(false);
+  const [ttsEnabled, setTTSEnabled] = useState(true);
+
+  const textTTSService = useRef<TextContentTTSService>(new TextContentTTSService());
+  const textDisplayRef = useRef<HTMLDivElement>(null);
 
   const handleRecordingComplete = (audioBlob: Blob) => {
     if (followAlongTarget) {
@@ -71,6 +86,8 @@ export const ReaderPage = () => {
   const fullSessionData = useRef<GazePacket[]>([]);
   const animationFrameRef = useRef<number>();
   const prevGazeRef = useRef<{ x: number; y: number } | null>(null);
+  const fixationTracker = useRef<{ startTime: number; x: number; y: number } | null>(null);
+  const prevNodCountRef = useRef(0);
 
   // Initialize gaze event handlers
   const { processEvent, resetSession, setWordPopupVisible } = useGazeEvents({
@@ -361,7 +378,28 @@ export const ReaderPage = () => {
           console.error('Error processing gaze event:', error);
           // Continue processing other packets even if one fails
         }
-        
+
+        if (packet.gaze_valid === 1) {
+          if (!fixationTracker.current) {
+            fixationTracker.current = { startTime: packet.timestamp, x: packet.gaze_pos_x, y: packet.gaze_pos_y };
+          } else {
+            const dist = Math.hypot(packet.gaze_pos_x - fixationTracker.current.x, packet.gaze_pos_y - fixationTracker.current.y);
+            if (dist > 50) {
+              fixationTracker.current = { startTime: packet.timestamp, x: packet.gaze_pos_x, y: packet.gaze_pos_y };
+            } else {
+              const dur = packet.timestamp - fixationTracker.current.startTime;
+              textTTSService.current.handleGazeFixation(packet.gaze_pos_x, packet.gaze_pos_y, dur);
+            }
+          }
+        } else {
+          fixationTracker.current = null;
+        }
+
+        if (currentNodCount > prevNodCountRef.current) {
+          textTTSService.current.handleNodGesture(packet.gaze_pos_x, packet.gaze_pos_y);
+          prevNodCountRef.current = currentNodCount;
+        }
+
         processed++;
       }
       
@@ -548,12 +586,40 @@ export const ReaderPage = () => {
                   </Button>
                 )}
                 
-                {isGazeActive && (
-                  <Badge className="bg-green-100 text-green-800">
-                    👁️ AI 助理啟動
-                  </Badge>
-                )}
-              </div>
+              {isGazeActive && (
+                <Badge className="bg-green-100 text-green-800">
+                  👁️ AI 助理啟動
+                </Badge>
+              )}
+              <Button
+                variant={ttsEnabled ? 'default' : 'outline'}
+                size="sm"
+                onClick={() => {
+                  const newVal = !ttsEnabled;
+                  textTTSService.current.updateSettings({ enabled: newVal });
+                  setTTSEnabled(newVal);
+                }}
+                className="flex items-center space-x-1"
+              >
+                {ttsEnabled ? <Volume2 className="h-4 w-4" /> : <Square className="h-4 w-4" />}
+                <span>{ttsEnabled ? 'TTS開啟' : 'TTS關閉'}</span>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowTTSSettings(true)}
+              >
+                <Settings className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => textTTSService.current.stop()}
+                disabled={!ttsEnabled}
+              >
+                <Square className="h-4 w-4" />
+              </Button>
+            </div>
               
               <Button
                 onClick={handleFinishReading}
@@ -569,11 +635,13 @@ export const ReaderPage = () => {
         {/* Reading Text */}
         <Card>
           <CardContent className="p-8">
-            <TextDisplay
-              textContent={textContent}
-              elementPositionsRef={elementPositionsRef}
-              distractionElementId={distractionElementId}
-            />
+            <div ref={textDisplayRef}>
+              <TextDisplay
+                textContent={textContent}
+                elementPositionsRef={elementPositionsRef}
+                distractionElementId={distractionElementId}
+              />
+            </div>
           </CardContent>
         </Card>
 
@@ -659,6 +727,10 @@ export const ReaderPage = () => {
           originalText={feedbackData.text}
           onClose={() => setFeedbackData(null)}
         />
+      )}
+
+      {showTTSSettings && (
+        <TTSSettingsPanel service={textTTSService.current} onClose={() => setShowTTSSettings(false)} />
       )}
 
       {showGrammarHint && (

--- a/src/pages/VocabularyReviewPage.tsx
+++ b/src/pages/VocabularyReviewPage.tsx
@@ -56,36 +56,19 @@ export const VocabularyReviewPage = () => {
 
         <CardContent className="space-y-6 text-center">
           <div className="text-4xl font-bold py-10">{word}</div>
-          <div className="flex justify-around space-x-4">
-            <Button
-              onClick={handleKnown}
-              className="flex-1 bg-green-600 hover:bg-green-700"
-            >
-              記得
-            </Button>
-            <Button variant="outline" onClick={handleAgain} className="flex-1">
-              再一次
-            </Button>
-
-        <CardContent className="space-y-4 text-center">
           <div className="text-3xl font-bold flex justify-center space-x-1">
             {syllables.map((syl, i) => (
               <span key={i}>
                 {syl}
-                {i < syllables.length - 1 && (
-                  <span className="text-blue-600">•</span>
-                )}
+                {i < syllables.length - 1 && <span className="text-blue-600">•</span>}
               </span>
             ))}
           </div>
           <div className="flex justify-around">
             <Button onClick={handleKnown} className="bg-green-600 hover:bg-green-700">記得</Button>
             <Button variant="outline" onClick={handleAgain}>再一次</Button>
-
           </div>
-          <Button variant="ghost" onClick={() => navigate("/")}>
-            完成
-          </Button>
+          <Button variant="ghost" onClick={() => navigate('/')}>完成</Button>
         </CardContent>
       </Card>
     </div>

--- a/src/services/TTSService.ts
+++ b/src/services/TTSService.ts
@@ -1,0 +1,54 @@
+export interface TTSSettings {
+  enabled: boolean;
+  autoSpeak: boolean;
+  rate: number;
+  pitch: number;
+  volume: number;
+}
+
+export class TTSService {
+  private settings: TTSSettings;
+
+  constructor() {
+    const stored = localStorage.getItem('ttsSettings');
+    if (stored) {
+      try {
+        this.settings = { ...JSON.parse(stored) } as TTSSettings;
+      } catch {
+        this.settings = { enabled: true, autoSpeak: true, rate: 1, pitch: 1, volume: 1 };
+      }
+    } else {
+      this.settings = { enabled: true, autoSpeak: true, rate: 1, pitch: 1, volume: 1 };
+    }
+  }
+
+  public getSettings(): TTSSettings {
+    return this.settings;
+  }
+
+  public updateSettings(updates: Partial<TTSSettings>): void {
+    this.settings = { ...this.settings, ...updates };
+    localStorage.setItem('ttsSettings', JSON.stringify(this.settings));
+  }
+
+  public speak(text: string, opts?: Partial<TTSSettings>): Promise<void> {
+    return new Promise((resolve) => {
+      if (!('speechSynthesis' in window)) return resolve();
+      if (!this.settings.enabled) return resolve();
+      const u = new SpeechSynthesisUtterance(text);
+      const final = { ...this.settings, ...opts };
+      u.rate = final.rate;
+      u.pitch = final.pitch;
+      u.volume = final.volume;
+      speechSynthesis.cancel();
+      speechSynthesis.speak(u);
+      u.onend = () => resolve();
+    });
+  }
+
+  public stop(): void {
+    if ('speechSynthesis' in window) {
+      speechSynthesis.cancel();
+    }
+  }
+}

--- a/src/services/TextContentTTSService.ts
+++ b/src/services/TextContentTTSService.ts
@@ -1,0 +1,108 @@
+import { TTSService, TTSSettings } from './TTSService';
+
+interface TextRegion {
+  id: string;
+  text: string;
+  type: 'word' | 'sentence';
+  bounds: { x: number; y: number; width: number; height: number };
+}
+
+export class TextContentTTSService {
+  private regions = new Map<string, TextRegion>();
+  private container: HTMLElement | null = null;
+  private tts = new TTSService();
+
+  public async load(container: HTMLElement): Promise<void> {
+    this.container = container;
+    await new Promise((r) => setTimeout(r, 100));
+    this.updateRegions();
+  }
+
+  public updateRegions(): void {
+    if (!this.container) return;
+    this.regions.clear();
+    const containerRect = this.container.getBoundingClientRect();
+    const wordEls = this.container.querySelectorAll('[id^="word-"]');
+    wordEls.forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      this.regions.set(el.id, {
+        id: el.id,
+        text: el.textContent || '',
+        type: 'word',
+        bounds: {
+          x: rect.left - containerRect.left,
+          y: rect.top - containerRect.top,
+          width: rect.width,
+          height: rect.height,
+        },
+      });
+    });
+    const sentenceEls = this.container.querySelectorAll('[id^="sentence-"]');
+    sentenceEls.forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      this.regions.set(el.id, {
+        id: el.id,
+        text: el.textContent || '',
+        type: 'sentence',
+        bounds: {
+          x: rect.left - containerRect.left,
+          y: rect.top - containerRect.top,
+          width: rect.width,
+          height: rect.height,
+        },
+      });
+    });
+  }
+
+  private regionAt(x: number, y: number): TextRegion | null {
+    if (!this.container) return null;
+    const containerRect = this.container.getBoundingClientRect();
+    const relX = x - containerRect.left;
+    const relY = y - containerRect.top;
+    for (const region of this.regions.values()) {
+      const b = region.bounds;
+      if (relX >= b.x && relX <= b.x + b.width && relY >= b.y && relY <= b.y + b.height) {
+        return region;
+      }
+    }
+    return null;
+  }
+
+  public async handleGazeFixation(x: number, y: number, duration: number): Promise<TextRegion | null> {
+    const region = this.regionAt(x, y);
+    if (!region) return null;
+    const s = this.tts.getSettings();
+    if (!s.enabled || !s.autoSpeak) return region;
+    if (region.type === 'word' && duration > 800 && duration < 2000) {
+      await this.tts.speak(region.text, { rate: s.rate * 1.2, pitch: s.pitch });
+    } else if (region.type === 'sentence' && duration >= 2000) {
+      await this.tts.speak(region.text, { rate: s.rate, pitch: s.pitch });
+    }
+    return region;
+  }
+
+  public async handleNodGesture(x: number, y: number, type: 'single' | 'double' = 'single'): Promise<TextRegion | null> {
+    const region = this.regionAt(x, y);
+    if (!region || !this.tts.getSettings().enabled) return null;
+    const settings = this.tts.getSettings();
+    const rate = type === 'double' ? settings.rate * 0.7 : settings.rate;
+    await this.tts.speak(region.text, { rate, pitch: settings.pitch });
+    return region;
+  }
+
+  public speakText(text: string, opts?: Partial<TTSSettings>): Promise<void> {
+    return this.tts.speak(text, opts);
+  }
+
+  public stop(): void {
+    this.tts.stop();
+  }
+
+  public getSettings(): TTSSettings {
+    return this.tts.getSettings();
+  }
+
+  public updateSettings(s: Partial<TTSSettings>): void {
+    this.tts.updateSettings(s);
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `TTSService` and `TextContentTTSService`
- support TTS controls via new `TTSSettingsPanel` component
- integrate TTS service with gaze data in `ReaderPage`
- fix ESLint errors in `useGazeEvents` and `VocabularyReviewPage`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c969eda0c832b826a99049196489e