### PR TITLE
Attach gaze data to teacher chat

### DIFF
--- a/src/components/ChatInterface.tsx
+++ b/src/components/ChatInterface.tsx
@@ -59,6 +59,19 @@ export const ChatInterface = () => {
         content: m.content
       }));
 
+      try {
+        const gazeRes = await fetch('/realtime-demo.json');
+        if (gazeRes.ok) {
+          const gazeText = await gazeRes.text();
+          chatHistory.push({
+            role: 'system',
+            content: `The following JSON is the gaze presentation of the student:\n${gazeText}`
+          });
+        }
+      } catch (err) {
+        console.error('Failed to fetch gaze JSON', err);
+      }
+
       const res = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- attach the realtime gaze data JSON to each chat request

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688ce0f0a7bc832bbbf067db80e7514e