### PR TITLE
Add image upload to ImageReader

### DIFF
--- a/src/pages/ImageReaderPage.tsx
+++ b/src/pages/ImageReaderPage.tsx
@@ -4,18 +4,40 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import ImageDisplay from '@/components/reader/ImageDisplay';
 
-// Load png images from the public/image folder
-const items = [
+// Pages for the short story. Images are served from the public folder
+const pages = [
   {
     id: 'img1',
     src: '/image/sample.png',
     text: 'Emma has been learning English for two years.'
+  },
+  {
+    id: 'img2',
+    src: '/placeholder.svg',
+    text: 'She practices with her friends every day.'
+  },
+  {
+    id: 'img3',
+    src: '/image/sample.png',
+    text: 'Reading short stories helps her improve quickly.'
   }
 ];
 
 export const ImageReaderPage = () => {
   const { sessionId } = useParams<{ sessionId: string }>();
   const [focusId, setFocusId] = useState<string | null>(null);
+  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = ev => {
+      setUploadedImage(ev.target?.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
 
   const speak = (text: string) => {
     if ('speechSynthesis' in window) {
@@ -28,7 +50,7 @@ export const ImageReaderPage = () => {
 
   const triggerDistraction = (id: string) => {
     setFocusId(id);
-    speak(items.find(i => i.id === id)?.text || '');
+    speak(pages.find(i => i.id === id)?.text || '');
     setTimeout(() => setFocusId(null), 3000);
   };
 
@@ -39,17 +61,46 @@ export const ImageReaderPage = () => {
           <CardTitle className="text-lg">Image Reading Session</CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {items.map(item => (
-            <div key={item.id} className="space-y-2">
-              <ImageDisplay id={item.id} src={item.src} text={item.text} isHighlighted={focusId === item.id} />
-              <Button size="sm" onClick={() => speak(item.text)}>
-                Speak
-              </Button>
-            </div>
-          ))}
-          <Button variant="outline" onClick={() => triggerDistraction(items[0].id)}>
+          {(() => {
+            const page = pages[pageIndex];
+            return (
+              <div key={page.id} className="space-y-2 text-center">
+                <ImageDisplay id={page.id} src={page.src} text={page.text} isHighlighted={focusId === page.id} />
+                <p className="text-sm">{page.text}</p>
+                <Button size="sm" onClick={() => speak(page.text)}>
+                  Speak
+                </Button>
+              </div>
+            );
+          })()}
+          <div className="flex justify-between pt-2">
+            <Button variant="outline" onClick={() => setPageIndex(p => Math.max(0, p - 1))} disabled={pageIndex === 0}>
+              Previous
+            </Button>
+            <Button variant="outline" onClick={() => setPageIndex(p => Math.min(pages.length - 1, p + 1))} disabled={pageIndex === pages.length - 1}>
+              Next
+            </Button>
+          </div>
+          <Button variant="outline" onClick={() => triggerDistraction(pages[pageIndex].id)}>
             Simulate Distraction
           </Button>
+          <div className="pt-4 space-y-2">
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleImageUpload}
+              id="reader-image-upload"
+              className="hidden"
+            />
+            <label htmlFor="reader-image-upload">
+              <Button variant="outline" size="sm" asChild>
+                <div>上傳圖片</div>
+              </Button>
+            </label>
+            {uploadedImage && (
+              <ImageDisplay id="uploaded" src={uploadedImage} text="Uploaded image" />
+            )}
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- allow uploading and previewing an image during image reading sessions
- add multiple pages with next/previous navigation to read story images

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ce67857a4832ba8b821bfb053cfef