### PR TITLE
Fix missing vocabulary state in ReaderPage

### DIFF
--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -34,6 +34,9 @@ export const ReaderPage = () => {
   
   // Load reading text from the public/text folder
   const [textContent, setTextContent] = useState('');
+  const [vocabList, setVocabList] = useState<VocabularyItem[]>([]);
+  const [vocabIndex, setVocabIndex] = useState(0);
+  const vocabSetRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     fetch('/text/sample.txt')


### PR DESCRIPTION
## Summary
- add missing vocabulary state and refs so ReaderPage flashcard features work

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d99f68e44832b97a4da9a08507c33