### PR TITLE
Fix missing vocabulary state in ReaderPage

### DIFF
--- a/src/components/reader/WordPopup.tsx
+++ b/src/components/reader/WordPopup.tsx
@@ -1,13 +1,14 @@
-
-import { useState, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Volume2, Mic, X } from 'lucide-react';
 import { ttsService } from '@/services/TTSService';
+import type { VocabularyItem } from '@/types';
 
 interface WordPopupProps {
   word: string;
   position: { top: number; left: number };
+  entry?: VocabularyItem;
   onClose: () => void;
   onFollowAlong?: (text: string, position: { top: number; left: number }) => void;
 }
@@ -20,69 +21,34 @@ interface WordDefinition {
   examples: string[];
 }
 
-interface VocabEntry {
-  word: string;
-  pronunciation?: string;
-  part_of_speech?: string;
-  definition?: string;
-  examples?: string[];
-}
-
-export const WordPopup = ({ word, position, onClose, onFollowAlong }: WordPopupProps) => {
-  const [definition, setDefinition] = useState<WordDefinition | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+export const WordPopup = ({ word, position, entry, onClose, onFollowAlong }: WordPopupProps) => {
   const [isFlipped, setIsFlipped] = useState(false);
 
-  useEffect(() => {
-    const fetchDefinition = async () => {
-      setIsLoading(true);
-
-      try {
-        const res = await fetch('/vocab.json');
-        const list: VocabEntry[] = await res.json();
-        const entry = list.find((v) => v.word.toLowerCase() === word.toLowerCase());
-        if (entry) {
-          const def: WordDefinition = {
-            word: entry.word,
-            partOfSpeech: entry.part_of_speech || '',
-            definition: entry.definition || '',
-            pronunciation: entry.pronunciation || '',
-            examples: entry.examples || []
-          };
-          setDefinition(def);
-        } else {
-          setDefinition({
-            word,
-            partOfSpeech: '',
-            definition: 'No definition found.',
-            pronunciation: '',
-            examples: []
-          });
-        }
-      } catch (err) {
-        console.error('Failed to load vocab', err);
-        setDefinition({
-          word,
-          partOfSpeech: '',
-          definition: 'No definition found.',
-          pronunciation: '',
-          examples: []
-        });
-      }
-      setIsLoading(false);
+  const definition = useMemo<WordDefinition>(() => {
+    if (entry) {
+      return {
+        word: entry.word,
+        partOfSpeech: entry.part_of_speech || '',
+        definition: entry.definition || entry.explanation || '',
+        pronunciation: entry.pronunciation || '',
+        examples: entry.examples || [],
+      };
+    }
+    return {
+      word,
+      partOfSpeech: '',
+      definition: 'No definition found.',
+      pronunciation: '',
+      examples: [],
     };
-
-    fetchDefinition();
-  }, [word]);
+  }, [entry, word]);
 
   const playPronunciation = () => {
-    if (definition) {
-      const settings = ttsService.getSettings();
-      if (settings.enabled) {
-        ttsService
-          .speak(definition.word, { rate: settings.rate * 0.8 })
-          .catch((e) => console.error('TTS Error:', e));
-      }
+    const settings = ttsService.getSettings();
+    if (settings.enabled) {
+      ttsService
+        .speak(definition.word, { rate: settings.rate * 0.8 })
+        .catch((e) => console.error('TTS Error:', e));
     }
   };
 
@@ -97,72 +63,66 @@ export const WordPopup = ({ word, position, onClose, onFollowAlong }: WordPopupP
         onClick={(e) => e.stopPropagation()}
       >
         <CardContent className="p-4">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-            </div>
-          ) : definition && (
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-2">
-                  <h3 className="text-lg font-semibold text-blue-700">{definition.word}</h3>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={playPronunciation}
-                    className="text-blue-600 hover:text-blue-800 p-1 h-auto"
-                  >
-                    <Volume2 className="h-4 w-4" />
-                  </Button>
-                  {onFollowAlong && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onFollowAlong(definition.word, position)}
-                      className="text-green-600 hover:text-green-800 p-1 h-auto"
-                    >
-                      <Mic className="h-4 w-4" />
-                    </Button>
-                  )}
-                </div>
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2">
+                <h3 className="text-lg font-semibold text-blue-700">{definition.word}</h3>
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={onClose}
-                  className="text-gray-500 hover:text-gray-700 p-1 h-auto"
+                  onClick={playPronunciation}
+                  className="text-blue-600 hover:text-blue-800 p-1 h-auto"
                 >
-                  <X className="h-4 w-4" />
+                  <Volume2 className="h-4 w-4" />
                 </Button>
+                {onFollowAlong && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onFollowAlong(definition.word, position)}
+                    className="text-green-600 hover:text-green-800 p-1 h-auto"
+                  >
+                    <Mic className="h-4 w-4" />
+                  </Button>
+                )}
               </div>
-
-              {!isFlipped ? (
-                <div className="space-y-2" onClick={() => setIsFlipped(true)}>
-                  <div className="text-sm text-gray-600 italic">
-                    {definition.pronunciation} • {definition.partOfSpeech}
-                  </div>
-
-                  <div className="text-sm text-gray-800 leading-relaxed">
-                    {definition.definition}
-                  </div>
-
-                  <div className="space-y-1">
-                    <div className="text-xs font-medium text-gray-700">例句：</div>
-                    {definition.examples.map((example, index) => (
-                      <div key={index} className="text-xs text-gray-600 italic">
-                        • {example}
-                      </div>
-                    ))}
-                  </div>
-                  <div className="text-xs text-gray-500 text-right">點擊切換</div>
-                </div>
-              ) : (
-                <div className="text-sm text-gray-800" onClick={() => setIsFlipped(false)}>
-                  <p className="mb-2">將此單字加入複習清單！</p>
-                  <p className="text-xs text-gray-500">點擊返回</p>
-                </div>
-              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onClose}
+                className="text-gray-500 hover:text-gray-700 p-1 h-auto"
+              >
+                <X className="h-4 w-4" />
+              </Button>
             </div>
-          )}
+
+            {!isFlipped ? (
+              <div className="space-y-2" onClick={() => setIsFlipped(true)}>
+                <div className="text-sm text-gray-600 italic">
+                  {definition.pronunciation} • {definition.partOfSpeech}
+                </div>
+
+                <div className="text-sm text-gray-800 leading-relaxed">
+                  {definition.definition}
+                </div>
+
+                <div className="space-y-1">
+                  <div className="text-xs font-medium text-gray-700">例句：</div>
+                  {definition.examples.map((example, index) => (
+                    <div key={index} className="text-xs text-gray-600 italic">
+                      • {example}
+                    </div>
+                  ))}
+                </div>
+                <div className="text-xs text-gray-500 text-right">點擊切換</div>
+              </div>
+            ) : (
+              <div className="text-sm text-gray-800" onClick={() => setIsFlipped(false)}>
+                <p className="mb-2">將此單字加入複習清單！</p>
+                <p className="text-xs text-gray-500">點擊返回</p>
+              </div>
+            )}
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/src/pages/ReaderPage.tsx
+++ b/src/pages/ReaderPage.tsx
@@ -34,6 +34,8 @@ export const ReaderPage = () => {
   
   // Load reading text from the public/text folder
   const [textContent, setTextContent] = useState('');
+  const [vocabList, setVocabList] = useState<VocabularyItem[]>([]);
+  const vocabSetRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     fetch('/text/sample.txt')
@@ -803,6 +805,9 @@ export const ReaderPage = () => {
         <WordPopup
           word={wordPopup.word}
           position={wordPopup.position}
+          entry={vocabList.find(
+            (v) => v.word.toLowerCase() === wordPopup.word.toLowerCase()
+          )}
           onClose={() => setWordPopup(null)}
           onFollowAlong={(text, pos) =>
             setFollowAlongTarget({ text, position: { x: pos.left, y: pos.top } })

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,7 +85,11 @@ export interface Paragraph {
 
 export interface VocabularyItem {
   word: string;
-  explanation: string;
+  pronunciation?: string;
+  part_of_speech?: string;
+  definition?: string;
+  examples?: string[];
+  explanation?: string;
 }
 
 export interface ReadingMaterial {


### PR DESCRIPTION
## Summary
- preload vocabulary list on ReaderPage and pass entries to WordPopup
- remove popup fetches by reading shared vocabulary data
- expand `VocabularyItem` type to include dictionary fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d99f68e44832b97a4da9a08507c33